### PR TITLE
Updated Blueprint Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ More details in [Wiki](https://github.com/IATkachenko/HA-SleepAsAndroid/wiki/app
  
 ## Usage
 ### blueprint (recommended)
- 1. import [blueprint](blueprint.yaml):
+ 1. import [blueprint](blueprint/full.yaml):
     1. Got to Home Assistant `settings` 
     2. `blueprints` 
     3. `import blueprint` button


### PR DESCRIPTION
Fixed the blueprint link in the README as it was pointing to the previous blueprint.yml before it was moved.