### PR TITLE
Slalamander patch alarm wake up check

### DIFF
--- a/blueprint/SleepAsAndroidEntity.yaml
+++ b/blueprint/SleepAsAndroidEntity.yaml
@@ -1,0 +1,440 @@
+blueprint:
+  name: Sleep as Android MQTT sensor actions
+  description: Define actions based on Sleep As Android sensor states
+  domain: automation
+  source_url: https://github.com/IATkachenko/HA-SleepAsAndroid/blob/main/blueprint/SleepSensorBlueprint.yaml
+  input:
+    sleep_entity:
+      name: SleepAsAndroid Entity
+      description: 'Sleep As Android Integration Entity'
+      selector:
+        entity:
+          filter:
+            integration: sleep_as_android
+          multiple: false
+    person:
+      name: Person
+      description: Person for checking state
+      selector:
+        entity:
+          domain: person
+          multiple: false
+    state:
+      name: State
+      description: Person must be in this state
+      default: home
+    sleep_tracking_started:
+      name: sleep_tracking_started
+      description: sleep_tracking_started event
+      default: []
+      selector:
+        action: {}
+    sleep_tracking_stopped:
+      name: sleep_tracking_stopped
+      description: sleep_tracking_stopped event
+      default: []
+      selector:
+        action: {}
+    sleep_tracking_paused:
+      name: sleep_tracking_paused
+      description: sleep_tracking_paused event
+      default: []
+      selector:
+        action: {}
+    sleep_tracking_resumed:
+      name: sleep_tracking_resumed
+      description: sleep_tracking_resumed event
+      default: []
+      selector:
+        action: {}
+    alarm_snooze_clicked:
+      name: alarm_snooze_clicked
+      description: alarm_snooze_clicked event
+      default: []
+      selector:
+        action: {}
+    alarm_snooze_canceled:
+      name: alarm_snooze_canceled
+      description: alarm_snooze_canceled event
+      default: []
+      selector:
+        action: {}
+    time_to_bed_alarm_alert:
+      name: time_to_bed_alarm_alert
+      description: time_to_bed_alarm_alert event
+      default: []
+      selector:
+        action: {}
+    alarm_alert_start:
+      name: alarm_alert_start
+      description: alarm_alert_start event
+      default: []
+      selector:
+        action: {}
+    alarm_alert_dismiss:
+      name: alarm_alert_dismiss
+      description: alarm_alert_dismiss event
+      default: []
+      selector:
+        action: {}
+    alarm_skip_next:
+      name: alarm_skip_next
+      description: alarm_skip_next event
+      default: []
+      selector:
+        action: {}
+    show_skip_next_alarm:
+      name: show_skip_next_alarm
+      description: show_skip_next_alarm event
+      default: []
+      selector:
+        action: {}
+    rem:
+      name: rem
+      description: rem event
+      default: []
+      selector:
+        action: {}
+    smart_period:
+      name: smart_period
+      description: smart_period event
+      default: []
+      selector:
+        action: {}
+    before_smart_period:
+      name: before_smart_period
+      description: before_smart_period event
+      default: []
+      selector:
+        action: {}
+    lullaby_start:
+      name: lullaby_start
+      description: lullaby_start event
+      default: []
+      selector:
+        action: {}
+    lullaby_stop:
+      name: lullaby_stop
+      description: lullaby_stop event
+      default: []
+      selector:
+        action: {}
+    lullaby_volume_down:
+      name: lullaby_volume_down
+      description: lullaby_volume_down event
+      default: []
+      selector:
+        action: {}
+    deep_sleep:
+      name: deep_sleep
+      description: deep_sleep event
+      default: []
+      selector:
+        action: {}
+    light_sleep:
+      name: light_sleep
+      description: light_sleep event
+      default: []
+      selector:
+        action: {}
+    awake:
+      name: awake
+      description: awake event
+      default: []
+      selector:
+        action: {}
+    not_awake:
+      name: not_awake
+      description: not_awake event
+      default: []
+      selector:
+        action: {}
+    apnea_alarm:
+      name: apnea_alarm
+      description: apnea_alarm event
+      default: []
+      selector:
+        action: {}
+    antisnoring:
+      name: antisnoring
+      description: antisnoring event
+      default: []
+      selector:
+        action: {}
+    sound_event_snore:
+      name: sound_event_snore
+      description: sound_event_snore event
+      default: []
+      selector:
+        action: {}
+    sound_event_talk:
+      name: sound_event_talk
+      description: sound_event_talk event
+      default: []
+      selector:
+        action: {}
+    sound_event_cough:
+      name: sound_event_cough
+      description: sound_event_cough event
+      default: []
+      selector:
+        action: {}
+    sound_event_baby:
+      name: sound_event_baby
+      description: sound_event_baby event
+      default: []
+      selector:
+        action: {}
+    sound_event_laugh:
+      name: sound_event_laugh
+      description: sound_event_laugh event
+      default: []
+      selector:
+        action: {}
+    before_alarm:
+      name: before_alarm
+      description: before_alarm event
+      default: []
+      selector:
+        action: {}
+mode: queued
+max_exceeded: silent
+trigger:
+- platform: state
+  entity_id: !input sleep_entity
+  to: sleep_tracking_started
+  id: sleep_tracking_started
+- platform: state
+  entity_id: !input sleep_entity
+  to:  sleep_tracking_stopped
+  id: sleep_tracking_stopped
+- platform: state
+  entity_id: !input sleep_entity
+  to:  sleep_tracking_paused
+  id: sleep_tracking_paused
+- platform: state
+  entity_id: !input sleep_entity
+  to:  sleep_tracking_resumed
+  id: sleep_tracking_resumed
+- platform: state
+  entity_id: !input sleep_entity
+  to:  alarm_snooze_clicked
+  id: alarm_snooze_clicked
+- platform: state
+  entity_id: !input sleep_entity
+  to:  alarm_snooze_canceled
+  id: alarm_snooze_canceled
+- platform: state
+  entity_id: !input sleep_entity
+  to:  time_to_bed_alarm_alert
+  id: time_to_bed_alarm_alert
+- platform: state
+  entity_id: !input sleep_entity
+  to:  alarm_alert_start
+  id: alarm_alert_start
+- platform: state
+  entity_id: !input sleep_entity
+  to:  alarm_alert_dismiss
+  id: alarm_alert_dismiss
+- platform: state
+  entity_id: !input sleep_entity
+  to:  alarm_skip_next
+  id: alarm_skip_next
+- platform: state
+  entity_id: !input sleep_entity
+  to:  show_skip_next_alarm
+  id: show_skip_next_alarm
+- platform: state
+  entity_id: !input sleep_entity
+  to:  rem
+  id: rem
+- platform: state
+  entity_id: !input sleep_entity
+  to:  smart_period
+  id: smart_period
+- platform: state
+  entity_id: !input sleep_entity
+  to:  before_smart_period
+  id: before_smart_period
+- platform: state
+  entity_id: !input sleep_entity
+  to:  lullaby_start
+  id: lullaby_start
+- platform: state
+  entity_id: !input sleep_entity
+  to:  lullaby_stop
+  id: lullaby_stop
+- platform: state
+  entity_id: !input sleep_entity
+  to:  lullaby_volume_down
+  id: lullaby_volume_down
+- platform: state
+  entity_id: !input sleep_entity
+  to:  deep_sleep
+  id: deep_sleep
+- platform: state
+  entity_id: !input sleep_entity
+  to:  light_sleep
+  id: light_sleep
+- platform: state
+  entity_id: !input sleep_entity
+  to:  awake
+  id: awake
+- platform: state
+  entity_id: !input sleep_entity
+  to:  not_awake
+  id: not_awake
+- platform: state
+  entity_id: !input sleep_entity
+  to:  apnea_alarm
+  id: apnea_alarm
+- platform: state
+  entity_id: !input sleep_entity
+  to:  antisnoring
+  id: antisnoring
+- platform: state
+  entity_id: !input sleep_entity
+  to:  sound_event_snore
+  id: sound_event_snore
+- platform: state
+  entity_id: !input sleep_entity
+  to:  sound_event_talk
+  id: sound_event_talk
+- platform: state
+  entity_id: !input sleep_entity
+  to:  sound_event_cough
+  id: sound_event_cough
+- platform: state
+  entity_id: !input sleep_entity
+  to:  sound_event_baby
+  id: sound_event_baby
+- platform: state
+  entity_id: !input sleep_entity
+  to:  sound_event_laugh
+  id: sound_event_laugh
+- platform: state
+  entity_id: !input sleep_entity
+  to:  before_alarm
+  id: before_alarm
+condition:
+- condition: state
+  entity_id: !input person
+  state: !input state
+action:
+- choose:
+  - conditions:
+      condition: trigger
+      id: sleep_tracking_started
+    sequence: !input sleep_tracking_started
+  - conditions:
+      condition: trigger
+      id: sleep_tracking_stopped
+    sequence: !input sleep_tracking_stopped
+  - conditions:
+      condition: trigger
+      id: sleep_tracking_paused
+    sequence: !input sleep_tracking_paused
+  - conditions:
+      condition: trigger
+      id: sleep_tracking_resumed
+    sequence: !input sleep_tracking_resumed
+  - conditions:
+      condition: trigger
+      id: alarm_snooze_clicked
+    sequence: !input alarm_snooze_clicked
+  - conditions:
+      condition: trigger
+      id: alarm_snooze_canceled
+    sequence: !input alarm_snooze_canceled
+  - conditions:
+      condition: trigger
+      id: time_to_bed_alarm_alert
+    sequence: !input time_to_bed_alarm_alert
+  - conditions:
+      condition: trigger
+      id: alarm_alert_start
+    sequence: !input alarm_alert_start
+  - conditions:
+      condition: trigger
+      id: alarm_alert_dismiss
+    sequence: !input alarm_alert_dismiss
+  - conditions:
+      condition: trigger
+      id: alarm_skip_next
+    sequence: !input alarm_skip_next
+  - conditions:
+      condition: trigger
+      id: show_skip_next_alarm
+    sequence: !input show_skip_next_alarm
+  - conditions:
+      condition: trigger
+      id: rem
+    sequence: !input rem
+  - conditions:
+      condition: trigger
+      id: smart_period
+    sequence: !input smart_period
+  - conditions:
+      condition: trigger
+      id: before_smart_period
+    sequence: !input before_smart_period
+  - conditions:
+      condition: trigger
+      id: lullaby_start
+    sequence: !input lullaby_start
+  - conditions:
+      condition: trigger
+      id: lullaby_stop
+    sequence: !input lullaby_stop
+  - conditions:
+      condition: trigger
+      id: lullaby_volume_down
+    sequence: !input lullaby_volume_down
+  - conditions:
+      condition: trigger
+      id: deep_sleep
+    sequence: !input deep_sleep
+  - conditions:
+      condition: trigger
+      id: light_sleep
+    sequence: !input light_sleep
+  - conditions:
+      condition: trigger
+      id: awake
+    sequence: !input awake
+  - conditions:
+      condition: trigger
+      id: not_awake
+    sequence: !input not_awake
+  - conditions:
+      condition: trigger
+      id: apnea_alarm
+    sequence: !input apnea_alarm
+  - conditions:
+      condition: trigger
+      id: antisnoring
+    sequence: !input antisnoring
+  - conditions:
+      condition: trigger
+      id: sound_event_snore
+    sequence: !input sound_event_snore
+  - conditions:
+      condition: trigger
+      id: sound_event_talk
+    sequence: !input sound_event_talk
+  - conditions:
+      condition: trigger
+      id: sound_event_cough
+    sequence: !input sound_event_cough
+  - conditions:
+      condition: trigger
+      id: sound_event_baby
+    sequence: !input sound_event_baby
+  - conditions:
+      condition: trigger
+      id: sound_event_laugh
+    sequence: !input sound_event_laugh
+  - conditions:
+      condition: trigger
+      id: before_alarm
+    sequence: !input before_alarm

--- a/custom_components/sleep_as_android/const.py
+++ b/custom_components/sleep_as_android/const.py
@@ -39,4 +39,5 @@ sleep_tracking_states = [
     "sound_event_laugh",
     "before_alarm",
     "alarm_rescheduled",
+    "alarm_wake_up_check"
 ]

--- a/custom_components/sleep_as_android/manifest.json
+++ b/custom_components/sleep_as_android/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/IATkachenko/HA-SleepAsAndroid/issues",
   "quality_scale": "silver",
   "requirements": ["pyhaversion"],
-  "version": "0.1.0"
+  "version": "2.3.2"
 }

--- a/custom_components/sleep_as_android/manifest.json
+++ b/custom_components/sleep_as_android/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/IATkachenko/HA-SleepAsAndroid/issues",
   "quality_scale": "silver",
   "requirements": ["pyhaversion"],
-  "version": "2.3.2"
+  "version": "0.1.0"
 }


### PR DESCRIPTION
This adds the new automation event added in version [20250124](https://sleep.urbandroid.org/docs/general/release_notes.html#20250124), "alarm_wake_up_check" to the constants. 

Otherwise, the sensor does not update anymore when it receives that event.
There are some older commits to from the previous blueprint I contributed, though I believe that should be in the repo already.